### PR TITLE
Bump GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -9,7 +9,7 @@ jobs:
       - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
       - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
       - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
       - run: echo "🖥️ The workflow is now ready to test your code on the runner."
       - name: List files in the repository

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -9,8 +9,8 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@v4.2.2
+    - uses: actions/setup-node@v4.4.0
       with:
         node-version: lts/*
     - name: Install dependencies
@@ -19,7 +19,7 @@ jobs:
       run: npx playwright install --with-deps
     - name: Run Playwright tests
       run: npx playwright test
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v4.6.2
       if: ${{ !cancelled() }}
       with:
         name: playwright-report


### PR DESCRIPTION
## Summary
- Bumps `actions/checkout` to `v4.2.2`
- Bumps `actions/setup-node` to `v4.4.0`
- Bumps `actions/upload-artifact` to `v4.6.2`

Fixes the Node.js 20 deprecation warning — these versions support Node.js 24, which becomes the default on June 2nd, 2026.

## Test plan
- [x] Verify the Playwright Tests workflow runs successfully on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)