### PR TITLE
Bump GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -7,8 +7,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: lts/*
       - name: Install dependencies

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -9,7 +9,7 @@ jobs:
       - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
       - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
       - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
       - run: echo "🖥️ The workflow is now ready to test your code on the runner."
       - name: List files in the repository

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -9,7 +9,7 @@ jobs:
       - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
       - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
       - name: Check out repository code
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6.0.2
       - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
       - run: echo "🖥️ The workflow is now ready to test your code on the runner."
       - name: List files in the repository

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -9,8 +9,8 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@v4.2.2
+    - uses: actions/setup-node@v4.4.0
       with:
         node-version: lts/*
     - name: Install dependencies
@@ -19,7 +19,7 @@ jobs:
       run: npx playwright install --with-deps
     - name: Run Playwright tests
       run: npx playwright test
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v4.6.2
       if: ${{ !cancelled() }}
       with:
         name: playwright-report

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -9,8 +9,8 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4.2.2
-    - uses: actions/setup-node@v4.4.0
+    - uses: actions/checkout@v6.0.2
+    - uses: actions/setup-node@v6.4.0
       with:
         node-version: lts/*
     - name: Install dependencies
@@ -19,7 +19,7 @@ jobs:
       run: npx playwright install --with-deps
     - name: Run Playwright tests
       run: npx playwright test
-    - uses: actions/upload-artifact@v4.6.2
+    - uses: actions/upload-artifact@v7.0.1
       if: ${{ !cancelled() }}
       with:
         name: playwright-report

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -7,8 +7,8 @@ jobs:
   format-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: lts/*
       - name: Install dependencies

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -7,8 +7,8 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: lts/*
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- Updates `actions/checkout` from v4 → v6.0.2
- Updates `actions/setup-node` from v4 → v6.4.0
- Updates `actions/upload-artifact` from v4.6.2 → v7.0.1

Resolves Node.js 20 deprecation warnings ahead of the June 2, 2026 forced switch to Node.js 24 on GitHub Actions runners.

## Test plan
- [x] Verify Playwright Tests workflow runs successfully
- [x] Verify ESLint, Prettier, and TypeScript Check workflows pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)