### PR TITLE
Add TestCafe test suite for sarahncrowe.com

### DIFF
--- a/models/testcafe/personal-site-home.js
+++ b/models/testcafe/personal-site-home.js
@@ -1,0 +1,19 @@
+import { Selector } from 'testcafe';
+
+class PersonalSiteHome {
+  constructor() {
+    this.nav = Selector('[data-testid="navbar"]');
+    this.heroSection = Selector('[data-testid="hero-section"]');
+    this.aboutSection = Selector('[data-testid="about-section"]');
+    this.experienceSection = Selector('[data-testid="experience-section"]');
+    this.skillsSection = Selector('[data-testid="skills-section"]');
+    this.contactSection = Selector('[data-testid="contact-section"]');
+    this.heroHeading = Selector('[data-testid="hero-name"]');
+    this.aboutText = Selector('[data-testid="about-bio"]');
+    this.githubLink = Selector('[data-testid="contact-github"]');
+    this.linkedinLink = Selector('[data-testid="contact-linkedin"]');
+    this.contactEmail = Selector('[data-testid="contact-email"]');
+  }
+}
+
+export const personalSiteHome = new PersonalSiteHome();

--- a/models/testcafe/personal-site-projects.js
+++ b/models/testcafe/personal-site-projects.js
@@ -1,0 +1,17 @@
+import { Selector } from 'testcafe';
+
+class PersonalSiteProjects {
+  constructor() {
+    this.heading = Selector('h1');
+    this.description = Selector('[data-testid="repo-header"] p');
+    this.playwrightTab = Selector('[data-testid="tab-playwright"]');
+    this.testcafeTab = Selector('[data-testid="tab-testcafe"]');
+    this.cypressTab = Selector('[data-testid="tab-cypress"]');
+    this.fileBrowserPanel = Selector('[data-testid="file-browser"]');
+    this.fileItems = Selector('[data-testid^="file-"][data-testid*="."]');
+    this.githubLink = Selector('[data-testid="github-repo-link"]');
+    this.backToHomeLink = Selector('[data-testid="back-link"]');
+  }
+}
+
+export const personalSiteProjects = new PersonalSiteProjects();

--- a/tests/TestCafe/personal-site/tc-ps-01-home.js
+++ b/tests/TestCafe/personal-site/tc-ps-01-home.js
@@ -1,0 +1,62 @@
+import { ClientFunction } from 'testcafe';
+import { personalSiteHome as home } from '../../../models/testcafe/personal-site-home';
+
+const BASE_URL = 'https://sarahncrowe.com';
+
+const getTitle = ClientFunction(() => document.title);
+const getLocation = ClientFunction(() => document.location.href);
+
+fixture`Personal Site - Home`.page(BASE_URL);
+
+// Page Structure
+
+test('Page title contains "sarah crowe"', async t => {
+  const title = await getTitle();
+  await t.expect(title.toLowerCase()).contains('sarah crowe');
+});
+
+test('All major sections are visible', async t => {
+  await t
+    .expect(home.heroSection.visible)
+    .ok()
+    .expect(home.aboutSection.visible)
+    .ok()
+    .expect(home.experienceSection.visible)
+    .ok()
+    .expect(home.skillsSection.visible)
+    .ok()
+    .expect(home.contactSection.visible)
+    .ok();
+});
+
+// Navigation
+
+test('Nav bar is visible', async t => {
+  await t.expect(home.nav.visible).ok();
+});
+
+// Content
+
+test('Hero heading is visible and non-empty', async t => {
+  await t.expect(home.heroHeading.visible).ok().expect(home.heroHeading.innerText).notEql('');
+});
+
+test('About section text is visible and non-empty', async t => {
+  await t.expect(home.aboutText.visible).ok().expect(home.aboutText.innerText).notEql('');
+});
+
+// Links & Contact
+
+test('GitHub link href matches github.com/sarahncrowe', async t => {
+  const href = await home.githubLink.getAttribute('href');
+  await t.expect(href).match(/github\.com\/sarahncrowe/i);
+});
+
+test('LinkedIn link href matches linkedin.com/in/', async t => {
+  const href = await home.linkedinLink.getAttribute('href');
+  await t.expect(href).match(/linkedin\.com\/in\//i);
+});
+
+test('Contact email is visible', async t => {
+  await t.expect(home.contactEmail.visible).ok();
+});

--- a/tests/TestCafe/personal-site/tc-ps-02-projects.js
+++ b/tests/TestCafe/personal-site/tc-ps-02-projects.js
@@ -1,0 +1,56 @@
+import { ClientFunction } from 'testcafe';
+import { personalSiteProjects as projects } from '../../../models/testcafe/personal-site-projects';
+
+const BASE_URL = 'https://sarahncrowe.com/projects';
+const PROJECT_NAME = 'sample-automation';
+
+const getTitle = ClientFunction(() => document.title);
+const getLocation = ClientFunction(() => document.location.href);
+
+fixture`Personal Site - Projects`.page(BASE_URL);
+
+// Page Structure
+
+test('Page title contains "projects"', async t => {
+  const title = await getTitle();
+  await t.expect(title.toLowerCase()).contains('projects');
+});
+
+test('Project heading displays "sample-automation"', async t => {
+  await t.expect(projects.heading.innerText).eql(PROJECT_NAME);
+});
+
+test('Project description is visible and non-empty', async t => {
+  await t.expect(projects.description.visible).ok().expect(projects.description.innerText).notEql('');
+});
+
+// Framework Tabs
+
+test('All three framework tabs are visible', async t => {
+  await t.expect(projects.playwrightTab.visible).ok().expect(projects.testcafeTab.visible).ok().expect(projects.cypressTab.visible).ok();
+});
+
+test('Clicking TestCafe tab shows file browser', async t => {
+  await t.expect(projects.fileItems.nth(0).visible).ok({ timeout: 15000 }).click(projects.testcafeTab).expect(projects.fileBrowserPanel.visible).ok();
+});
+
+// File Browser
+
+test('Files are visible on load', async t => {
+  await t.expect(projects.fileItems.nth(0).visible).ok({ timeout: 15000 });
+  const count = await projects.fileItems.count;
+  await t.expect(count).gt(0);
+});
+
+// Links
+
+test('GitHub repo link href matches the repository URL', async t => {
+  const href = await projects.githubLink.getAttribute('href');
+  await t.expect(href).match(/github\.com\/sarahncrowe\/sample-automation/i);
+});
+
+test('Back-to-home link navigates to home page', async t => {
+  await t.click(projects.backToHomeLink);
+  const url = await getLocation();
+  await t.expect(url).eql('https://sarahncrowe.com/');
+});


### PR DESCRIPTION
## Summary

- Adds TestCafe page models for the personal site home and projects pages (`models/testcafe/personal-site-home.js`, `models/testcafe/personal-site-projects.js`), using the same `data-testid` selectors as the existing Playwright models
- Adds `tests/TestCafe/personal-site/tc-ps-01-home.js` — 8 tests covering page title, major sections, nav, hero/about content, and GitHub/LinkedIn/contact links
- Adds `tests/TestCafe/personal-site/tc-ps-02-projects.js` — 8 tests covering page title, project heading/description, framework tabs, file browser, GitHub repo link, and back-to-home navigation

Intentionally skips the slower Playwright tests (scroll-to-section loop, image naturalWidth iteration, external link attribute iteration, file code viewer) to keep the TestCafe suite lean.

## Test plan

- [x] `tc-ps-01-home.js` — 8 passed locally (~5s)
- [x] `tc-ps-02-projects.js` — 8 passed locally (~9s)
- [x] `npm run typecheck && npm run lint && npm run format:check` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)