### PR TITLE
Update personal site tests for experience card grid and modal (#5)

### DIFF
--- a/models/playwright/personal-site/home-page.ts
+++ b/models/playwright/personal-site/home-page.ts
@@ -16,6 +16,14 @@ class HomePage {
   readonly githubLink: Locator;
   readonly linkedinLink: Locator;
   readonly contactEmail: Locator;
+  readonly experienceList: Locator;
+  readonly experienceCards: Locator;
+  readonly experienceModal: Locator;
+  readonly modalClose: Locator;
+  readonly modalTitle: Locator;
+  readonly modalCompany: Locator;
+  readonly modalDescription: Locator;
+  readonly modalTags: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -33,6 +41,14 @@ class HomePage {
     this.githubLink = page.getByTestId('contact-github');
     this.linkedinLink = page.getByTestId('contact-linkedin');
     this.contactEmail = page.getByTestId('contact-email');
+    this.experienceList = page.getByTestId('experience-list');
+    this.experienceCards = page.locator('[data-testid^="experience-card-"]');
+    this.experienceModal = page.getByTestId('experience-modal');
+    this.modalClose = page.getByTestId('modal-close');
+    this.modalTitle = page.getByTestId('modal-title');
+    this.modalCompany = page.getByTestId('modal-company');
+    this.modalDescription = page.getByTestId('modal-description');
+    this.modalTags = page.getByTestId('modal-tags');
   }
 }
 

--- a/models/testcafe/personal-site-home.js
+++ b/models/testcafe/personal-site-home.js
@@ -14,6 +14,14 @@ class PersonalSiteHome {
     this.githubLink = Selector('[data-testid="contact-github"]');
     this.linkedinLink = Selector('[data-testid="contact-linkedin"]');
     this.contactEmail = Selector('[data-testid="contact-email"]');
+    this.experienceList = Selector('[data-testid="experience-list"]');
+    this.experienceCard = index => Selector(`[data-testid="experience-card-${index}"]`);
+    this.experienceModal = Selector('[data-testid="experience-modal"]');
+    this.modalClose = Selector('[data-testid="modal-close"]');
+    this.modalTitle = Selector('[data-testid="modal-title"]');
+    this.modalCompany = Selector('[data-testid="modal-company"]');
+    this.modalDescription = Selector('[data-testid="modal-description"]');
+    this.modalTags = Selector('[data-testid="modal-tags"]');
   }
 }
 

--- a/tests/TestCafe/personal-site/tc-ps-01-home.js
+++ b/tests/TestCafe/personal-site/tc-ps-01-home.js
@@ -45,6 +45,35 @@ test('About section text is visible and non-empty', async t => {
   await t.expect(home.aboutText.visible).ok().expect(home.aboutText.innerText).notEql('');
 });
 
+// Experience
+
+test('Experience card grid is visible', async t => {
+  await t.expect(home.experienceList.visible).ok().expect(home.experienceCard(0).visible).ok();
+});
+
+test('Clicking an experience card opens the modal with content', async t => {
+  await t.click(home.experienceCard(0)).expect(home.experienceModal.visible).ok().expect(home.modalTitle.innerText).notEql('');
+});
+
+test('Experience modal closes when X button is clicked', async t => {
+  await t.click(home.experienceCard(0)).expect(home.experienceModal.visible).ok().click(home.modalClose).expect(home.experienceModal.exists).notOk();
+});
+
+test('Experience modal closes when Escape key is pressed', async t => {
+  await t.click(home.experienceCard(0)).expect(home.experienceModal.visible).ok().pressKey('esc').expect(home.experienceModal.exists).notOk();
+});
+
+test('Company name in modal links to LinkedIn profile and shows the LinkedIn icon', async t => {
+  await t
+    .click(home.experienceCard(0))
+    .expect(home.experienceModal.visible)
+    .ok()
+    .expect(home.modalCompany.getAttribute('href'))
+    .match(/linkedin\.com/i)
+    .expect(home.modalCompany.find('svg').visible)
+    .ok();
+});
+
 // Links & Contact
 
 test('GitHub link href matches github.com/sarahncrowe', async t => {

--- a/tests/playwright/personal-site/home.spec.ts
+++ b/tests/playwright/personal-site/home.spec.ts
@@ -69,6 +69,50 @@ test.describe('Content', () => {
   });
 });
 
+test.describe('Experience', () => {
+  test('Experience card grid is visible with all cards', async ({ page }) => {
+    const home = new HomePage(page);
+    await expect(home.experienceList).toBeVisible();
+    const cards = await home.experienceCards.all();
+    expect(cards.length).toBeGreaterThan(0);
+    for (const card of cards) {
+      await expect(card).toBeVisible();
+    }
+  });
+
+  test('Clicking an experience card opens the modal with content', async ({ page }) => {
+    const home = new HomePage(page);
+    await home.experienceCards.first().click();
+    await expect(home.experienceModal).toBeVisible();
+    await expect(home.modalTitle).not.toBeEmpty();
+    await expect(home.modalDescription).not.toBeEmpty();
+  });
+
+  test('Experience modal closes when X button is clicked', async ({ page }) => {
+    const home = new HomePage(page);
+    await home.experienceCards.first().click();
+    await expect(home.experienceModal).toBeVisible();
+    await home.modalClose.click();
+    await expect(home.experienceModal).toBeHidden();
+  });
+
+  test('Experience modal closes when Escape key is pressed', async ({ page }) => {
+    const home = new HomePage(page);
+    await home.experienceCards.first().click();
+    await expect(home.experienceModal).toBeVisible();
+    await page.keyboard.press('Escape');
+    await expect(home.experienceModal).toBeHidden();
+  });
+
+  test('Company name in modal links to LinkedIn profile and shows the LinkedIn icon', async ({ page }) => {
+    const home = new HomePage(page);
+    await home.experienceCards.first().click();
+    await expect(home.experienceModal).toBeVisible();
+    await expect(home.modalCompany).toHaveAttribute('href', /linkedin\.com/i);
+    await expect(home.modalCompany.locator('svg')).toBeVisible();
+  });
+});
+
 test.describe('Links & Contact', () => {
   test('User can navigate to GitHub profile', async ({ page }) => {
     const home = new HomePage(page);


### PR DESCRIPTION
Aligns Playwright and TestCafe tests with the replacement of the vertical timeline with an interactive card grid and modal. Adds locators and tests for card visibility, modal open/close (X button and Escape), and verifying the company name links to its LinkedIn profile with the icon visible.