### PR TITLE
Add dark mode toggle tests for Playwright and TestCafe

### DIFF
--- a/models/playwright/personal-site/home-page.ts
+++ b/models/playwright/personal-site/home-page.ts
@@ -24,6 +24,7 @@ class HomePage {
   readonly modalCompany: Locator;
   readonly modalDescription: Locator;
   readonly modalTags: Locator;
+  readonly darkModeToggle: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -49,6 +50,7 @@ class HomePage {
     this.modalCompany = page.getByTestId('modal-company');
     this.modalDescription = page.getByTestId('modal-description');
     this.modalTags = page.getByTestId('modal-tags');
+    this.darkModeToggle = page.getByTestId('dark-mode-toggle');
   }
 }
 

--- a/models/testcafe/personal-site-home.js
+++ b/models/testcafe/personal-site-home.js
@@ -22,6 +22,7 @@ class PersonalSiteHome {
     this.modalCompany = Selector('[data-testid="modal-company"]');
     this.modalDescription = Selector('[data-testid="modal-description"]');
     this.modalTags = Selector('[data-testid="modal-tags"]');
+    this.darkModeToggle = Selector('[data-testid="dark-mode-toggle"]');
   }
 }
 

--- a/tests/TestCafe/personal-site/tc-ps-01-home.js
+++ b/tests/TestCafe/personal-site/tc-ps-01-home.js
@@ -1,6 +1,10 @@
 import { ClientFunction } from 'testcafe';
 import { personalSiteHome as home } from '../../../models/testcafe/personal-site-home';
 
+const setTheme = ClientFunction(theme => localStorage.setItem('theme', theme));
+const getTheme = ClientFunction(() => localStorage.getItem('theme'));
+const getHtmlClass = ClientFunction(() => document.documentElement.className);
+
 const BASE_URL = 'https://sarahncrowe.com';
 
 const getTitle = ClientFunction(() => document.title);
@@ -88,4 +92,37 @@ test('LinkedIn link href matches linkedin.com/in/', async t => {
 
 test('Contact email is visible', async t => {
   await t.expect(home.contactEmail.visible).ok();
+});
+
+// Dark Mode
+
+fixture`Personal Site - Home - Dark Mode`.page(BASE_URL).beforeEach(async t => {
+  await setTheme('light');
+  await t.navigateTo(BASE_URL);
+});
+
+test('Dark mode toggle is visible in the navbar', async t => {
+  await t.expect(home.darkModeToggle.visible).ok();
+});
+
+test('User can enable dark mode', async t => {
+  await t.expect(getHtmlClass()).notContains('dark');
+  await t.expect(home.darkModeToggle.find('i').hasClass('fa-moon')).ok();
+  await t.click(home.darkModeToggle);
+  await t.expect(getHtmlClass()).contains('dark').expect(home.darkModeToggle.getAttribute('aria-pressed')).eql('true');
+  await t.expect(home.darkModeToggle.find('i').hasClass('fa-sun')).ok();
+});
+
+test('User can disable dark mode', async t => {
+  await t.click(home.darkModeToggle);
+  await t.expect(getHtmlClass()).contains('dark');
+  await t.expect(home.darkModeToggle.find('i').hasClass('fa-sun')).ok();
+  await t.click(home.darkModeToggle);
+  await t.expect(getHtmlClass()).notContains('dark').expect(home.darkModeToggle.getAttribute('aria-pressed')).eql('false');
+  await t.expect(home.darkModeToggle.find('i').hasClass('fa-moon')).ok();
+});
+
+test('Dark mode preference is saved to localStorage', async t => {
+  await t.click(home.darkModeToggle);
+  await t.expect(getTheme()).eql('dark');
 });

--- a/tests/TestCafe/personal-site/tc-ps-01-home.js
+++ b/tests/TestCafe/personal-site/tc-ps-01-home.js
@@ -107,19 +107,19 @@ test('Dark mode toggle is visible in the navbar', async t => {
 
 test('User can enable dark mode', async t => {
   await t.expect(getHtmlClass()).notContains('dark');
-  await t.expect(home.darkModeToggle.find('i').hasClass('fa-moon')).ok();
+  await t.expect(home.darkModeToggle.find('svg[data-icon="moon"]').exists).ok();
   await t.click(home.darkModeToggle);
   await t.expect(getHtmlClass()).contains('dark').expect(home.darkModeToggle.getAttribute('aria-pressed')).eql('true');
-  await t.expect(home.darkModeToggle.find('i').hasClass('fa-sun')).ok();
+  await t.expect(home.darkModeToggle.find('svg[data-icon="sun"]').exists).ok();
 });
 
 test('User can disable dark mode', async t => {
   await t.click(home.darkModeToggle);
   await t.expect(getHtmlClass()).contains('dark');
-  await t.expect(home.darkModeToggle.find('i').hasClass('fa-sun')).ok();
+  await t.expect(home.darkModeToggle.find('svg[data-icon="sun"]').exists).ok();
   await t.click(home.darkModeToggle);
   await t.expect(getHtmlClass()).notContains('dark').expect(home.darkModeToggle.getAttribute('aria-pressed')).eql('false');
-  await t.expect(home.darkModeToggle.find('i').hasClass('fa-moon')).ok();
+  await t.expect(home.darkModeToggle.find('svg[data-icon="moon"]').exists).ok();
 });
 
 test('Dark mode preference is saved to localStorage', async t => {

--- a/tests/playwright/personal-site/home.spec.ts
+++ b/tests/playwright/personal-site/home.spec.ts
@@ -113,6 +113,46 @@ test.describe('Experience', () => {
   });
 });
 
+test.describe('Dark Mode', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.evaluate(() => localStorage.setItem('theme', 'light'));
+    await page.reload();
+  });
+
+  test('Dark mode toggle is visible in the navbar', async ({ page }) => {
+    const home = new HomePage(page);
+    await expect(home.darkModeToggle).toBeVisible();
+  });
+
+  test('User can enable dark mode', async ({ page }) => {
+    const home = new HomePage(page);
+    await expect(page.locator('html')).not.toHaveClass('dark');
+    await expect(home.darkModeToggle.locator('i')).toHaveClass('fa-moon');
+    await home.darkModeToggle.click();
+    await expect(page.locator('html')).toHaveClass('dark');
+    await expect(home.darkModeToggle).toHaveAttribute('aria-pressed', 'true');
+    await expect(home.darkModeToggle.locator('i')).toHaveClass('fa-sun');
+  });
+
+  test('User can disable dark mode', async ({ page }) => {
+    const home = new HomePage(page);
+    await home.darkModeToggle.click();
+    await expect(page.locator('html')).toHaveClass('dark');
+    await expect(home.darkModeToggle.locator('i')).toHaveClass('fa-sun');
+    await home.darkModeToggle.click();
+    await expect(page.locator('html')).not.toHaveClass('dark');
+    await expect(home.darkModeToggle).toHaveAttribute('aria-pressed', 'false');
+    await expect(home.darkModeToggle.locator('i')).toHaveClass('fa-moon');
+  });
+
+  test('Dark mode preference is saved to localStorage', async ({ page }) => {
+    const home = new HomePage(page);
+    await home.darkModeToggle.click();
+    const theme = await page.evaluate(() => localStorage.getItem('theme'));
+    expect(theme).toBe('dark');
+  });
+});
+
 test.describe('Links & Contact', () => {
   test('User can navigate to GitHub profile', async ({ page }) => {
     const home = new HomePage(page);

--- a/tests/playwright/personal-site/home.spec.ts
+++ b/tests/playwright/personal-site/home.spec.ts
@@ -126,23 +126,23 @@ test.describe('Dark Mode', () => {
 
   test('User can enable dark mode', async ({ page }) => {
     const home = new HomePage(page);
-    await expect(page.locator('html')).not.toHaveClass('dark');
-    await expect(home.darkModeToggle.locator('i')).toHaveClass('fa-moon');
+    await expect(page.locator('html')).not.toHaveClass(/\bdark\b/);
+    await expect(home.darkModeToggle.locator('svg[data-icon="moon"]')).toBeVisible();
     await home.darkModeToggle.click();
-    await expect(page.locator('html')).toHaveClass('dark');
+    await expect(page.locator('html')).toHaveClass(/\bdark\b/);
     await expect(home.darkModeToggle).toHaveAttribute('aria-pressed', 'true');
-    await expect(home.darkModeToggle.locator('i')).toHaveClass('fa-sun');
+    await expect(home.darkModeToggle.locator('svg[data-icon="sun"]')).toBeVisible();
   });
 
   test('User can disable dark mode', async ({ page }) => {
     const home = new HomePage(page);
     await home.darkModeToggle.click();
-    await expect(page.locator('html')).toHaveClass('dark');
-    await expect(home.darkModeToggle.locator('i')).toHaveClass('fa-sun');
+    await expect(page.locator('html')).toHaveClass(/\bdark\b/);
+    await expect(home.darkModeToggle.locator('svg[data-icon="sun"]')).toBeVisible();
     await home.darkModeToggle.click();
-    await expect(page.locator('html')).not.toHaveClass('dark');
+    await expect(page.locator('html')).not.toHaveClass(/\bdark\b/);
     await expect(home.darkModeToggle).toHaveAttribute('aria-pressed', 'false');
-    await expect(home.darkModeToggle.locator('i')).toHaveClass('fa-moon');
+    await expect(home.darkModeToggle.locator('svg[data-icon="moon"]')).toBeVisible();
   });
 
   test('Dark mode preference is saved to localStorage', async ({ page }) => {


### PR DESCRIPTION
## Summary

- Adds `darkModeToggle` locator to both the Playwright and TestCafe page models
- Adds a Dark Mode test suite to both `home.spec.ts` and `tc-ps-01-home.js` covering: toggle visibility, enabling dark mode, disabling dark mode (with icon checks for moon/sun), and localStorage persistence

## Test plan

- [x] Dark mode toggle is visible in the navbar
- [x] Enabling dark mode: `html` gets `dark` class, `aria-pressed` becomes `true`, sun icon appears
- [x] Disabling dark mode: `html` loses `dark` class, `aria-pressed` becomes `false`, moon icon appears
- [x] Dark mode preference is saved to `localStorage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)