### PR TITLE
Support BASE_URL env var for running personal site tests locally

### DIFF
--- a/cypress.config.cjs
+++ b/cypress.config.cjs
@@ -2,7 +2,7 @@ const { defineConfig } = require('cypress');
 
 module.exports = defineConfig({
   e2e: {
-    baseUrl: 'https://sarahncrowe.com',
+    baseUrl: process.env.BASE_URL || 'https://sarahncrowe.com',
     specPattern: 'tests/cypress/integration/**/*.js',
     supportFile: 'tests/cypress/support/index.js',
   },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,11 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint",
     "format:check": "prettier --check .",
-    "test:cypress": "cypress run"
+    "test": "playwright test",
+    "test:cypress": "cypress run",
+    "test:local": "BASE_URL=http://localhost:5173 playwright test --project=personal-site-chrome --project=personal-site-firefox --project=personal-site-safari",
+    "test:local:cypress": "BASE_URL=http://localhost:5173 cypress run",
+    "test:local:testcafe": "BASE_URL=http://localhost:5173 npx testcafe chrome tests/TestCafe/personal-site"
   },
   "repository": {
     "type": "git",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -49,19 +49,19 @@ module.exports = defineConfig({
 
     {
       name: 'personal-site-chrome',
-      use: { ...devices['Desktop Chrome'], baseURL: 'https://sarahncrowe.com' },
+      use: { ...devices['Desktop Chrome'], baseURL: process.env.BASE_URL || 'https://sarahncrowe.com' },
       testMatch: '**/personal-site/**/*.spec.ts',
     },
 
     {
       name: 'personal-site-firefox',
-      use: { ...devices['Desktop Firefox'], baseURL: 'https://sarahncrowe.com' },
+      use: { ...devices['Desktop Firefox'], baseURL: process.env.BASE_URL || 'https://sarahncrowe.com' },
       testMatch: '**/personal-site/**/*.spec.ts',
     },
 
     {
       name: 'personal-site-safari',
-      use: { ...devices['Desktop Safari'], baseURL: 'https://sarahncrowe.com' },
+      use: { ...devices['Desktop Safari'], baseURL: process.env.BASE_URL || 'https://sarahncrowe.com' },
       testMatch: '**/personal-site/**/*.spec.ts',
     },
   ],

--- a/tests/TestCafe/personal-site/tc-ps-01-home.js
+++ b/tests/TestCafe/personal-site/tc-ps-01-home.js
@@ -5,7 +5,7 @@ const setTheme = ClientFunction(theme => localStorage.setItem('theme', theme));
 const getTheme = ClientFunction(() => localStorage.getItem('theme'));
 const getHtmlClass = ClientFunction(() => document.documentElement.className);
 
-const BASE_URL = 'https://sarahncrowe.com';
+const BASE_URL = process.env.BASE_URL || 'https://sarahncrowe.com';
 
 const getTitle = ClientFunction(() => document.title);
 const getLocation = ClientFunction(() => document.location.href);

--- a/tests/TestCafe/personal-site/tc-ps-02-projects.js
+++ b/tests/TestCafe/personal-site/tc-ps-02-projects.js
@@ -1,7 +1,7 @@
 import { ClientFunction } from 'testcafe';
 import { personalSiteProjects as projects } from '../../../models/testcafe/personal-site-projects';
 
-const BASE_URL = 'https://sarahncrowe.com/projects';
+const BASE_URL = `${process.env.BASE_URL || 'https://sarahncrowe.com'}/projects`;
 const PROJECT_NAME = 'sample-automation';
 
 const getTitle = ClientFunction(() => document.title);


### PR DESCRIPTION
## Summary
- Replaces hardcoded `https://sarahncrowe.com` with `process.env.BASE_URL` (falling back to production) in Playwright, Cypress, and TestCafe configs
- Adds `test:local`, `test:local:cypress`, and `test:local:testcafe` npm scripts defaulting to `localhost:5173`
- `npm test` now runs Playwright by default

## Usage
```bash
# Run against local dev server (default port)
npm run test:local            # Playwright — personal site, all browsers
npm run test:local:cypress    # Cypress
npm run test:local:testcafe   # TestCafe

# Override the port
BASE_URL=http://localhost:3000 npm run test:local

# Production (no change needed)
npm test
```

## Test plan
- [ ] Start local dev server and run `npm run test:local` — confirm tests hit localhost
- [ ] Run `npm test` without `BASE_URL` set — confirm tests fall back to `https://sarahncrowe.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)