### PR TITLE
Add arrow navigation tests for experience modal

### DIFF
--- a/models/cypress/personal-site-home.js
+++ b/models/cypress/personal-site-home.js
@@ -22,6 +22,8 @@ class PersonalSiteHome {
     this.modalCompany = '[data-testid="modal-company"]';
     this.modalDescription = '[data-testid="modal-description"]';
     this.modalTags = '[data-testid="modal-tags"]';
+    this.modalPrev = '[data-testid="modal-prev"]';
+    this.modalNext = '[data-testid="modal-next"]';
     this.darkModeToggle = '[data-testid="dark-mode-toggle"]';
   }
 

--- a/models/playwright/personal-site/home-page.ts
+++ b/models/playwright/personal-site/home-page.ts
@@ -24,6 +24,8 @@ class HomePage {
   readonly modalCompany: Locator;
   readonly modalDescription: Locator;
   readonly modalTags: Locator;
+  readonly modalPrev: Locator;
+  readonly modalNext: Locator;
   readonly darkModeToggle: Locator;
 
   constructor(page: Page) {
@@ -50,6 +52,8 @@ class HomePage {
     this.modalCompany = page.getByTestId('modal-company');
     this.modalDescription = page.getByTestId('modal-description');
     this.modalTags = page.getByTestId('modal-tags');
+    this.modalPrev = page.getByTestId('modal-prev');
+    this.modalNext = page.getByTestId('modal-next');
     this.darkModeToggle = page.getByTestId('dark-mode-toggle');
   }
 }

--- a/models/testcafe/personal-site-home.js
+++ b/models/testcafe/personal-site-home.js
@@ -22,6 +22,8 @@ class PersonalSiteHome {
     this.modalCompany = Selector('[data-testid="modal-company"]');
     this.modalDescription = Selector('[data-testid="modal-description"]');
     this.modalTags = Selector('[data-testid="modal-tags"]');
+    this.modalPrev = Selector('[data-testid="modal-prev"]');
+    this.modalNext = Selector('[data-testid="modal-next"]');
     this.darkModeToggle = Selector('[data-testid="dark-mode-toggle"]');
   }
 }

--- a/tests/TestCafe/personal-site/tc-ps-01-home.js
+++ b/tests/TestCafe/personal-site/tc-ps-01-home.js
@@ -1,4 +1,4 @@
-import { ClientFunction } from 'testcafe';
+import { ClientFunction, Selector } from 'testcafe';
 import { personalSiteHome as home } from '../../../models/testcafe/personal-site-home';
 
 const setTheme = ClientFunction(theme => localStorage.setItem('theme', theme));
@@ -65,6 +65,66 @@ test('Experience modal closes when X button is clicked', async t => {
 
 test('Experience modal closes when Escape key is pressed', async t => {
   await t.click(home.experienceCard(0)).expect(home.experienceModal.visible).ok().pressKey('esc').expect(home.experienceModal.exists).notOk();
+});
+
+test('First card does not show previous arrow', async t => {
+  await t.click(home.experienceCard(0)).expect(home.experienceModal.visible).ok().expect(home.modalPrev.exists).notOk();
+});
+
+test('First card shows next arrow', async t => {
+  await t.click(home.experienceCard(0)).expect(home.experienceModal.visible).ok().expect(home.modalNext.visible).ok();
+});
+
+test('Clicking next arrow navigates to the next card', async t => {
+  await t.click(home.experienceCard(0)).expect(home.experienceModal.visible).ok();
+  const firstTitle = await home.modalTitle.innerText;
+  await t.click(home.modalNext);
+  await t.expect(home.modalTitle.innerText).notEql(firstTitle).expect(home.modalPrev.visible).ok();
+});
+
+test('Last card does not show next arrow', async t => {
+  const cardCount = await Selector('[data-testid^="experience-card-"]').count;
+  await t
+    .click(home.experienceCard(cardCount - 1))
+    .expect(home.experienceModal.visible)
+    .ok()
+    .expect(home.modalNext.exists)
+    .notOk();
+});
+
+test('Last card shows previous arrow', async t => {
+  const cardCount = await Selector('[data-testid^="experience-card-"]').count;
+  await t
+    .click(home.experienceCard(cardCount - 1))
+    .expect(home.experienceModal.visible)
+    .ok()
+    .expect(home.modalPrev.visible)
+    .ok();
+});
+
+test('Clicking previous arrow navigates to the previous card', async t => {
+  const cardCount = await Selector('[data-testid^="experience-card-"]').count;
+  await t
+    .click(home.experienceCard(cardCount - 1))
+    .expect(home.experienceModal.visible)
+    .ok();
+  const lastTitle = await home.modalTitle.innerText;
+  await t.click(home.modalPrev);
+  await t.expect(home.modalTitle.innerText).notEql(lastTitle).expect(home.modalNext.visible).ok();
+});
+
+test('ArrowRight key navigates to the next card', async t => {
+  await t.click(home.experienceCard(0)).expect(home.experienceModal.visible).ok();
+  const firstTitle = await home.modalTitle.innerText;
+  await t.pressKey('right');
+  await t.expect(home.modalTitle.innerText).notEql(firstTitle);
+});
+
+test('ArrowLeft key navigates to the previous card', async t => {
+  await t.click(home.experienceCard(1)).expect(home.experienceModal.visible).ok();
+  const secondTitle = await home.modalTitle.innerText;
+  await t.pressKey('left');
+  await t.expect(home.modalTitle.innerText).notEql(secondTitle).expect(home.modalPrev.exists).notOk();
 });
 
 test('Company name in modal links to LinkedIn profile and shows the LinkedIn icon', async t => {

--- a/tests/cypress/integration/personal-site/cy-ps-01-home.js
+++ b/tests/cypress/integration/personal-site/cy-ps-01-home.js
@@ -88,6 +88,77 @@ describe('Experience', function () {
     cy.get(home.experienceModal).should('not.exist');
   });
 
+  it('First card does not show previous arrow', () => {
+    cy.get(home.experienceCard(0)).click();
+    cy.get(home.experienceModal).should('be.visible');
+    cy.get(home.modalPrev).should('not.exist');
+  });
+
+  it('First card shows next arrow', () => {
+    cy.get(home.experienceCard(0)).click();
+    cy.get(home.experienceModal).should('be.visible');
+    cy.get(home.modalNext).should('be.visible');
+  });
+
+  it('Clicking next arrow navigates to the next card', () => {
+    cy.get(home.experienceCard(0)).click();
+    cy.get(home.experienceModal).should('be.visible');
+    cy.get(home.modalTitle)
+      .invoke('text')
+      .then(firstTitle => {
+        cy.get(home.modalNext).click();
+        cy.get(home.modalTitle).should('not.have.text', firstTitle);
+        cy.get(home.modalPrev).should('be.visible');
+      });
+  });
+
+  it('Last card does not show next arrow', () => {
+    cy.get(home.experienceCards).last().click();
+    cy.get(home.experienceModal).should('be.visible');
+    cy.get(home.modalNext).should('not.exist');
+  });
+
+  it('Last card shows previous arrow', () => {
+    cy.get(home.experienceCards).last().click();
+    cy.get(home.experienceModal).should('be.visible');
+    cy.get(home.modalPrev).should('be.visible');
+  });
+
+  it('Clicking previous arrow navigates to the previous card', () => {
+    cy.get(home.experienceCards).last().click();
+    cy.get(home.experienceModal).should('be.visible');
+    cy.get(home.modalTitle)
+      .invoke('text')
+      .then(lastTitle => {
+        cy.get(home.modalPrev).click();
+        cy.get(home.modalTitle).should('not.have.text', lastTitle);
+        cy.get(home.modalNext).should('be.visible');
+      });
+  });
+
+  it('ArrowRight key navigates to the next card', () => {
+    cy.get(home.experienceCard(0)).click();
+    cy.get(home.experienceModal).should('be.visible');
+    cy.get(home.modalTitle)
+      .invoke('text')
+      .then(firstTitle => {
+        cy.get('body').type('{rightarrow}');
+        cy.get(home.modalTitle).should('not.have.text', firstTitle);
+      });
+  });
+
+  it('ArrowLeft key navigates to the previous card', () => {
+    cy.get(home.experienceCard(1)).click();
+    cy.get(home.experienceModal).should('be.visible');
+    cy.get(home.modalTitle)
+      .invoke('text')
+      .then(secondTitle => {
+        cy.get('body').type('{leftarrow}');
+        cy.get(home.modalTitle).should('not.have.text', secondTitle);
+        cy.get(home.modalPrev).should('not.exist');
+      });
+  });
+
   it('Company name in modal links to LinkedIn profile and shows the LinkedIn icon', () => {
     cy.get(home.experienceCard(0)).click();
     cy.get(home.experienceModal).should('be.visible');

--- a/tests/playwright/personal-site/home.spec.ts
+++ b/tests/playwright/personal-site/home.spec.ts
@@ -104,6 +104,74 @@ test.describe('Experience', () => {
     await expect(home.experienceModal).toBeHidden();
   });
 
+  test('First card does not show previous arrow', async ({ page }) => {
+    const home = new HomePage(page);
+    await home.experienceCards.first().click();
+    await expect(home.experienceModal).toBeVisible();
+    await expect(home.modalPrev).not.toBeAttached();
+  });
+
+  test('First card shows next arrow', async ({ page }) => {
+    const home = new HomePage(page);
+    await home.experienceCards.first().click();
+    await expect(home.experienceModal).toBeVisible();
+    await expect(home.modalNext).toBeVisible();
+  });
+
+  test('Clicking next arrow navigates to the next card', async ({ page }) => {
+    const home = new HomePage(page);
+    await home.experienceCards.first().click();
+    await expect(home.experienceModal).toBeVisible();
+    const firstTitle = await home.modalTitle.textContent();
+    await home.modalNext.click();
+    await expect(home.modalTitle).not.toHaveText(firstTitle!);
+    await expect(home.modalPrev).toBeVisible();
+  });
+
+  test('Last card does not show next arrow', async ({ page }) => {
+    const home = new HomePage(page);
+    await home.experienceCards.last().click();
+    await expect(home.experienceModal).toBeVisible();
+    await expect(home.modalNext).not.toBeAttached();
+  });
+
+  test('Last card shows previous arrow', async ({ page }) => {
+    const home = new HomePage(page);
+    await home.experienceCards.last().click();
+    await expect(home.experienceModal).toBeVisible();
+    await expect(home.modalPrev).toBeVisible();
+  });
+
+  test('Clicking previous arrow navigates to the previous card', async ({ page }) => {
+    const home = new HomePage(page);
+    await home.experienceCards.last().click();
+    await expect(home.experienceModal).toBeVisible();
+    const lastTitle = await home.modalTitle.textContent();
+    await home.modalPrev.click();
+    await expect(home.modalTitle).not.toHaveText(lastTitle!);
+    await expect(home.modalNext).toBeVisible();
+  });
+
+  test('ArrowRight key navigates to the next card', async ({ page }) => {
+    const home = new HomePage(page);
+    await home.experienceCards.first().click();
+    await expect(home.experienceModal).toBeVisible();
+    const firstTitle = await home.modalTitle.textContent();
+    await page.keyboard.press('ArrowRight');
+    await expect(home.modalTitle).not.toHaveText(firstTitle!);
+  });
+
+  test('ArrowLeft key navigates to the previous card', async ({ page }) => {
+    const home = new HomePage(page);
+    const cards = await home.experienceCards.all();
+    await cards[1].click();
+    await expect(home.experienceModal).toBeVisible();
+    const secondTitle = await home.modalTitle.textContent();
+    await page.keyboard.press('ArrowLeft');
+    await expect(home.modalTitle).not.toHaveText(secondTitle!);
+    await expect(home.modalPrev).not.toBeAttached();
+  });
+
   test('Company name in modal links to LinkedIn profile and shows the LinkedIn icon', async ({ page }) => {
     const home = new HomePage(page);
     await home.experienceCards.first().click();


### PR DESCRIPTION
## Summary

- Added `modal-prev` and `modal-next` selectors to all three page object models (Playwright, Cypress, TestCafe)
- Added 8 new tests per framework covering the arrow navigation feature added to the experience card modal

**Tests added:**
- First card has no previous arrow (button not rendered)
- First card shows next arrow
- Clicking next arrow navigates to the next card
- Last card has no next arrow
- Last card shows previous arrow
- Clicking previous arrow navigates to the previous card
- `ArrowRight` key navigates to the next card
- `ArrowLeft` key navigates to the previous card

## Test plan

- [ ] Playwright: `npx playwright test tests/playwright/personal-site/home.spec.ts`
- [ ] Cypress: `npx cypress run --spec "tests/cypress/integration/personal-site/cy-ps-01-home.js"`
- [ ] TestCafe: `npx testcafe chrome tests/TestCafe/personal-site/tc-ps-01-home.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)