### PR TITLE
Schedule Cypress, Playwright, and TestCafe to run twice weekly

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,5 +1,8 @@
 name: Cypress Tests
 on:
+  schedule:
+    - cron: '0 12 * * 6'  # Saturday noon UTC (8am EDT / 7am EST)
+    - cron: '0 12 * * 3'  # Wednesday noon UTC
   pull_request:
   workflow_dispatch:
 jobs:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -3,6 +3,9 @@
 
 name: Playwright Tests
 on:
+  schedule:
+    - cron: '0 12 * * 6'  # Saturday noon UTC (8am EDT / 7am EST)
+    - cron: '0 12 * * 3'  # Wednesday noon UTC
   pull_request:
   workflow_dispatch:
 jobs:

--- a/.github/workflows/testcafe.yml
+++ b/.github/workflows/testcafe.yml
@@ -1,5 +1,8 @@
 name: TestCafe Tests
 on:
+  schedule:
+    - cron: '0 12 * * 6'  # Saturday noon UTC (8am EDT / 7am EST)
+    - cron: '0 12 * * 3'  # Wednesday noon UTC
   pull_request:
   workflow_dispatch:
 jobs:


### PR DESCRIPTION
## Summary
- Adds a `schedule` trigger to the Cypress, Playwright, and TestCafe workflows
- Runs every Wednesday and Saturday at noon UTC (8am EDT / 7am EST)
- Existing `pull_request` and `workflow_dispatch` triggers are unchanged

## Test plan
- [ ] Verify workflows appear in the GitHub Actions schedule after merging to `main`
- [ ] Manually trigger each workflow via `workflow_dispatch` to confirm they still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)