### PR TITLE
Update contact email tests to verify contact@sarahncrowe.com

### DIFF
--- a/tests/TestCafe/personal-site/tc-ps-01-home.js
+++ b/tests/TestCafe/personal-site/tc-ps-01-home.js
@@ -150,8 +150,10 @@ test('LinkedIn link href matches linkedin.com/in/', async t => {
   await t.expect(href).match(/linkedin\.com\/in\//i);
 });
 
-test('Contact email is visible', async t => {
+test('Contact email is visible and correct', async t => {
   await t.expect(home.contactEmail.visible).ok();
+  await t.expect(home.contactEmail.getAttribute('href')).eql('mailto:contact@sarahncrowe.com');
+  await t.expect(home.contactEmail.getAttribute('aria-label')).eql('Email contact@sarahncrowe.com');
 });
 
 // Dark Mode

--- a/tests/cypress/integration/personal-site/cy-ps-01-home.js
+++ b/tests/cypress/integration/personal-site/cy-ps-01-home.js
@@ -219,6 +219,8 @@ describe('Links & Contact', function () {
 
   it('User can find contact information', () => {
     cy.get(home.contactEmail).should('be.visible');
+    cy.get(home.contactEmail).invoke('attr', 'href').should('eq', 'mailto:contact@sarahncrowe.com');
+    cy.get(home.contactEmail).should('have.attr', 'aria-label', 'Email contact@sarahncrowe.com');
   });
 
   it('User can open external links in a new tab', () => {

--- a/tests/playwright/personal-site/home.spec.ts
+++ b/tests/playwright/personal-site/home.spec.ts
@@ -235,6 +235,8 @@ test.describe('Links & Contact', () => {
   test('User can find contact information', async ({ page }) => {
     const home = new HomePage(page);
     await expect(home.contactEmail).toBeVisible();
+    await expect(home.contactEmail).toHaveAttribute('href', 'mailto:contact@sarahncrowe.com');
+    await expect(home.contactEmail).toHaveAttribute('aria-label', 'Email contact@sarahncrowe.com');
   });
 
   test('User can open external links in a new tab', async ({ page }) => {


### PR DESCRIPTION
## Summary

- Extends the existing contact email visibility test in Playwright, Cypress, and TestCafe to also assert the correct `href` (`mailto:contact@sarahncrowe.com`) and `aria-label` (`Email contact@sarahncrowe.com`) on the icon link
- The email is not displayed as visible text — it is accessible via `aria-label`, so tests assert that instead of text content

## Test plan

- [x] All three test suites run and pass locally
- [x] `npm run typecheck`, `npm run lint`, `npm run format:check` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)