### PR TITLE
Use repo-description testid directly in ProjectsPage POM

### DIFF
--- a/models/playwright/personal-site/projects-page.ts
+++ b/models/playwright/personal-site/projects-page.ts
@@ -18,7 +18,7 @@ class ProjectsPage {
   constructor(page: Page) {
     this.page = page;
     this.heading = page.getByRole('heading', { level: 1 });
-    this.description = page.getByTestId('repo-header').locator('p');
+    this.description = page.getByTestId('repo-description');
     this.playwrightTab = page.getByTestId('tab-playwright');
     this.testcafeTab = page.getByTestId('tab-testcafe');
     this.cypressTab = page.getByTestId('tab-cypress');


### PR DESCRIPTION
## Summary
- Updates `ProjectsPage` POM to use `page.getByTestId('repo-description')` directly, replacing the scoped `page.getByTestId('repo-header').locator('p')` locator
- Follows up on sarahncrowe/jubilant-octo-website#2, which added `data-testid="repo-description"` to the description `<p>` element

## Test plan
- [ ] Run Playwright tests against the updated site to confirm the `description` locator resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)