### PR TITLE
Consolidate duplicate test setup across home page test suites

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "test:cypress": "cypress run",
     "test:local": "BASE_URL=http://localhost:5173 playwright test --project=personal-site-chrome --project=personal-site-firefox --project=personal-site-safari",
     "test:local:cypress": "BASE_URL=http://localhost:5173 cypress run",
-    "test:local:testcafe": "BASE_URL=http://localhost:5173 npx testcafe chrome tests/TestCafe/personal-site"
+    "test:testcafe": "npx testcafe chrome tests/TestCafe/personal-site --skip-js-errors",
+    "test:local:testcafe": "BASE_URL=http://localhost:5173 npx testcafe chrome tests/TestCafe/personal-site --skip-js-errors"
   },
   "repository": {
     "type": "git",

--- a/tests/TestCafe/personal-site/tc-ps-01-home.js
+++ b/tests/TestCafe/personal-site/tc-ps-01-home.js
@@ -51,91 +51,98 @@ test('About section text is visible and non-empty', async t => {
 
 // Experience
 
+async function openFirstCard(t) {
+  await t.click(home.experienceCard(0)).expect(home.experienceModal.visible).ok();
+}
+
+async function openLastCard(t) {
+  const cardCount = await Selector('[data-testid^="experience-card-"]').count;
+  await t
+    .click(home.experienceCard(cardCount - 1))
+    .expect(home.experienceModal.visible)
+    .ok();
+}
+
 test('Experience card grid is visible', async t => {
   await t.expect(home.experienceList.visible).ok().expect(home.experienceCard(0).visible).ok();
 });
 
-test('Clicking an experience card opens the modal with content', async t => {
-  await t.click(home.experienceCard(0)).expect(home.experienceModal.visible).ok().expect(home.modalTitle.innerText).notEql('');
+// when the first experience card is open
+
+test('The modal displays content', async t => {
+  await openFirstCard(t);
+  await t.expect(home.modalTitle.innerText).notEql('');
 });
 
-test('Experience modal closes when X button is clicked', async t => {
-  await t.click(home.experienceCard(0)).expect(home.experienceModal.visible).ok().click(home.modalClose).expect(home.experienceModal.exists).notOk();
+test('The modal closes when X button is clicked', async t => {
+  await openFirstCard(t);
+  await t.click(home.modalClose).expect(home.experienceModal.exists).notOk();
 });
 
-test('Experience modal closes when Escape key is pressed', async t => {
-  await t.click(home.experienceCard(0)).expect(home.experienceModal.visible).ok().pressKey('esc').expect(home.experienceModal.exists).notOk();
+test('The modal closes when Escape key is pressed', async t => {
+  await openFirstCard(t);
+  await t.pressKey('esc').expect(home.experienceModal.exists).notOk();
 });
 
-test('First card does not show previous arrow', async t => {
-  await t.click(home.experienceCard(0)).expect(home.experienceModal.visible).ok().expect(home.modalPrev.exists).notOk();
+test('The previous arrow is not shown', async t => {
+  await openFirstCard(t);
+  await t.expect(home.modalPrev.exists).notOk();
 });
 
-test('First card shows next arrow', async t => {
-  await t.click(home.experienceCard(0)).expect(home.experienceModal.visible).ok().expect(home.modalNext.visible).ok();
+test('The next arrow is shown', async t => {
+  await openFirstCard(t);
+  await t.expect(home.modalNext.visible).ok();
 });
 
 test('Clicking next arrow navigates to the next card', async t => {
-  await t.click(home.experienceCard(0)).expect(home.experienceModal.visible).ok();
+  await openFirstCard(t);
   const firstTitle = await home.modalTitle.innerText;
   await t.click(home.modalNext);
   await t.expect(home.modalTitle.innerText).notEql(firstTitle).expect(home.modalPrev.visible).ok();
 });
 
-test('Last card does not show next arrow', async t => {
-  const cardCount = await Selector('[data-testid^="experience-card-"]').count;
-  await t
-    .click(home.experienceCard(cardCount - 1))
-    .expect(home.experienceModal.visible)
-    .ok()
-    .expect(home.modalNext.exists)
-    .notOk();
+test('ArrowRight key navigates to the next card', async t => {
+  await openFirstCard(t);
+  const firstTitle = await home.modalTitle.innerText;
+  await t.pressKey('right');
+  await t.expect(home.modalTitle.innerText).notEql(firstTitle);
 });
 
-test('Last card shows previous arrow', async t => {
-  const cardCount = await Selector('[data-testid^="experience-card-"]').count;
+test('Company name links to LinkedIn profile and shows the LinkedIn icon', async t => {
+  await openFirstCard(t);
   await t
-    .click(home.experienceCard(cardCount - 1))
-    .expect(home.experienceModal.visible)
-    .ok()
-    .expect(home.modalPrev.visible)
+    .expect(home.modalCompany.getAttribute('href'))
+    .match(/linkedin\.com/i)
+    .expect(home.modalCompany.find('svg').visible)
     .ok();
+});
+
+// when the last experience card is open
+
+test('The next arrow is not shown', async t => {
+  await openLastCard(t);
+  await t.expect(home.modalNext.exists).notOk();
+});
+
+test('The previous arrow is shown', async t => {
+  await openLastCard(t);
+  await t.expect(home.modalPrev.visible).ok();
 });
 
 test('Clicking previous arrow navigates to the previous card', async t => {
-  const cardCount = await Selector('[data-testid^="experience-card-"]').count;
-  await t
-    .click(home.experienceCard(cardCount - 1))
-    .expect(home.experienceModal.visible)
-    .ok();
+  await openLastCard(t);
   const lastTitle = await home.modalTitle.innerText;
   await t.click(home.modalPrev);
   await t.expect(home.modalTitle.innerText).notEql(lastTitle).expect(home.modalNext.visible).ok();
 });
 
-test('ArrowRight key navigates to the next card', async t => {
-  await t.click(home.experienceCard(0)).expect(home.experienceModal.visible).ok();
-  const firstTitle = await home.modalTitle.innerText;
-  await t.pressKey('right');
-  await t.expect(home.modalTitle.innerText).notEql(firstTitle);
-});
+// standalone
 
 test('ArrowLeft key navigates to the previous card', async t => {
   await t.click(home.experienceCard(1)).expect(home.experienceModal.visible).ok();
   const secondTitle = await home.modalTitle.innerText;
   await t.pressKey('left');
   await t.expect(home.modalTitle.innerText).notEql(secondTitle).expect(home.modalPrev.exists).notOk();
-});
-
-test('Company name in modal links to LinkedIn profile and shows the LinkedIn icon', async t => {
-  await t
-    .click(home.experienceCard(0))
-    .expect(home.experienceModal.visible)
-    .ok()
-    .expect(home.modalCompany.getAttribute('href'))
-    .match(/linkedin\.com/i)
-    .expect(home.modalCompany.find('svg').visible)
-    .ok();
 });
 
 // Links & Contact
@@ -167,17 +174,11 @@ test('Dark mode toggle is visible in the navbar', async t => {
   await t.expect(home.darkModeToggle.visible).ok();
 });
 
-test('User can enable dark mode', async t => {
+test('User can toggle dark mode on and off', async t => {
   await t.expect(getHtmlClass()).notContains('dark');
   await t.expect(home.darkModeToggle.find('svg[data-icon="moon"]').exists).ok();
   await t.click(home.darkModeToggle);
   await t.expect(getHtmlClass()).contains('dark').expect(home.darkModeToggle.getAttribute('aria-pressed')).eql('true');
-  await t.expect(home.darkModeToggle.find('svg[data-icon="sun"]').exists).ok();
-});
-
-test('User can disable dark mode', async t => {
-  await t.click(home.darkModeToggle);
-  await t.expect(getHtmlClass()).contains('dark');
   await t.expect(home.darkModeToggle.find('svg[data-icon="sun"]').exists).ok();
   await t.click(home.darkModeToggle);
   await t.expect(getHtmlClass()).notContains('dark').expect(home.darkModeToggle.getAttribute('aria-pressed')).eql('false');

--- a/tests/cypress/integration/personal-site/cy-ps-01-home.js
+++ b/tests/cypress/integration/personal-site/cy-ps-01-home.js
@@ -67,84 +67,85 @@ describe('Experience', function () {
     });
   });
 
-  it('Clicking an experience card opens the modal with content', () => {
-    cy.get(home.experienceCard(0)).click();
-    cy.get(home.experienceModal).should('be.visible');
-    cy.get(home.modalTitle).should('not.be.empty');
-    cy.get(home.modalDescription).should('not.be.empty');
+  describe('when the first experience card is open', function () {
+    beforeEach(() => {
+      cy.get(home.experienceCard(0)).click();
+      cy.get(home.experienceModal).should('be.visible');
+    });
+
+    it('The modal displays content', () => {
+      cy.get(home.modalTitle).should('not.be.empty');
+      cy.get(home.modalDescription).should('not.be.empty');
+    });
+
+    it('The modal closes when X button is clicked', () => {
+      cy.get(home.modalClose).click();
+      cy.get(home.experienceModal).should('not.exist');
+    });
+
+    it('The modal closes when Escape key is pressed', () => {
+      cy.get('body').type('{esc}');
+      cy.get(home.experienceModal).should('not.exist');
+    });
+
+    it('The previous arrow is not shown', () => {
+      cy.get(home.modalPrev).should('not.exist');
+    });
+
+    it('The next arrow is shown', () => {
+      cy.get(home.modalNext).should('be.visible');
+    });
+
+    it('Clicking next arrow navigates to the next card', () => {
+      cy.get(home.modalTitle)
+        .invoke('text')
+        .then(firstTitle => {
+          cy.get(home.modalNext).click();
+          cy.get(home.modalTitle).should('not.have.text', firstTitle);
+          cy.get(home.modalPrev).should('be.visible');
+        });
+    });
+
+    it('ArrowRight key navigates to the next card', () => {
+      cy.get(home.modalTitle)
+        .invoke('text')
+        .then(firstTitle => {
+          cy.get('body').type('{rightarrow}');
+          cy.get(home.modalTitle).should('not.have.text', firstTitle);
+        });
+    });
+
+    it('Company name links to LinkedIn profile and shows the LinkedIn icon', () => {
+      cy.get(home.modalCompany)
+        .invoke('attr', 'href')
+        .should('match', /linkedin\.com/i);
+      cy.get(home.modalCompany).find('svg').should('be.visible');
+    });
   });
 
-  it('Experience modal closes when X button is clicked', () => {
-    cy.get(home.experienceCard(0)).click();
-    cy.get(home.experienceModal).should('be.visible');
-    cy.get(home.modalClose).click();
-    cy.get(home.experienceModal).should('not.exist');
-  });
+  describe('when the last experience card is open', function () {
+    beforeEach(() => {
+      cy.get(home.experienceCards).last().click();
+      cy.get(home.experienceModal).should('be.visible');
+    });
 
-  it('Experience modal closes when Escape key is pressed', () => {
-    cy.get(home.experienceCard(0)).click();
-    cy.get(home.experienceModal).should('be.visible');
-    cy.get('body').type('{esc}');
-    cy.get(home.experienceModal).should('not.exist');
-  });
+    it('The next arrow is not shown', () => {
+      cy.get(home.modalNext).should('not.exist');
+    });
 
-  it('First card does not show previous arrow', () => {
-    cy.get(home.experienceCard(0)).click();
-    cy.get(home.experienceModal).should('be.visible');
-    cy.get(home.modalPrev).should('not.exist');
-  });
+    it('The previous arrow is shown', () => {
+      cy.get(home.modalPrev).should('be.visible');
+    });
 
-  it('First card shows next arrow', () => {
-    cy.get(home.experienceCard(0)).click();
-    cy.get(home.experienceModal).should('be.visible');
-    cy.get(home.modalNext).should('be.visible');
-  });
-
-  it('Clicking next arrow navigates to the next card', () => {
-    cy.get(home.experienceCard(0)).click();
-    cy.get(home.experienceModal).should('be.visible');
-    cy.get(home.modalTitle)
-      .invoke('text')
-      .then(firstTitle => {
-        cy.get(home.modalNext).click();
-        cy.get(home.modalTitle).should('not.have.text', firstTitle);
-        cy.get(home.modalPrev).should('be.visible');
-      });
-  });
-
-  it('Last card does not show next arrow', () => {
-    cy.get(home.experienceCards).last().click();
-    cy.get(home.experienceModal).should('be.visible');
-    cy.get(home.modalNext).should('not.exist');
-  });
-
-  it('Last card shows previous arrow', () => {
-    cy.get(home.experienceCards).last().click();
-    cy.get(home.experienceModal).should('be.visible');
-    cy.get(home.modalPrev).should('be.visible');
-  });
-
-  it('Clicking previous arrow navigates to the previous card', () => {
-    cy.get(home.experienceCards).last().click();
-    cy.get(home.experienceModal).should('be.visible');
-    cy.get(home.modalTitle)
-      .invoke('text')
-      .then(lastTitle => {
-        cy.get(home.modalPrev).click();
-        cy.get(home.modalTitle).should('not.have.text', lastTitle);
-        cy.get(home.modalNext).should('be.visible');
-      });
-  });
-
-  it('ArrowRight key navigates to the next card', () => {
-    cy.get(home.experienceCard(0)).click();
-    cy.get(home.experienceModal).should('be.visible');
-    cy.get(home.modalTitle)
-      .invoke('text')
-      .then(firstTitle => {
-        cy.get('body').type('{rightarrow}');
-        cy.get(home.modalTitle).should('not.have.text', firstTitle);
-      });
+    it('Clicking previous arrow navigates to the previous card', () => {
+      cy.get(home.modalTitle)
+        .invoke('text')
+        .then(lastTitle => {
+          cy.get(home.modalPrev).click();
+          cy.get(home.modalTitle).should('not.have.text', lastTitle);
+          cy.get(home.modalNext).should('be.visible');
+        });
+    });
   });
 
   it('ArrowLeft key navigates to the previous card', () => {
@@ -158,15 +159,6 @@ describe('Experience', function () {
         cy.get(home.modalPrev).should('not.exist');
       });
   });
-
-  it('Company name in modal links to LinkedIn profile and shows the LinkedIn icon', () => {
-    cy.get(home.experienceCard(0)).click();
-    cy.get(home.experienceModal).should('be.visible');
-    cy.get(home.modalCompany)
-      .invoke('attr', 'href')
-      .should('match', /linkedin\.com/i);
-    cy.get(home.modalCompany).find('svg').should('be.visible');
-  });
 });
 
 describe('Dark Mode', function () {
@@ -179,18 +171,12 @@ describe('Dark Mode', function () {
     cy.get(home.darkModeToggle).should('be.visible');
   });
 
-  it('User can enable dark mode', () => {
+  it('User can toggle dark mode on and off', () => {
     cy.get('html').should('not.have.class', 'dark');
     cy.get(home.darkModeToggle).find('svg[data-icon="moon"]').should('exist');
     cy.get(home.darkModeToggle).click();
     cy.get('html').should('have.class', 'dark');
     cy.get(home.darkModeToggle).should('have.attr', 'aria-pressed', 'true');
-    cy.get(home.darkModeToggle).find('svg[data-icon="sun"]').should('exist');
-  });
-
-  it('User can disable dark mode', () => {
-    cy.get(home.darkModeToggle).click();
-    cy.get('html').should('have.class', 'dark');
     cy.get(home.darkModeToggle).find('svg[data-icon="sun"]').should('exist');
     cy.get(home.darkModeToggle).click();
     cy.get('html').should('not.have.class', 'dark');

--- a/tests/playwright/personal-site/home.spec.ts
+++ b/tests/playwright/personal-site/home.spec.ts
@@ -80,85 +80,87 @@ test.describe('Experience', () => {
     }
   });
 
-  test('Clicking an experience card opens the modal with content', async ({ page }) => {
-    const home = new HomePage(page);
-    await home.experienceCards.first().click();
-    await expect(home.experienceModal).toBeVisible();
-    await expect(home.modalTitle).not.toBeEmpty();
-    await expect(home.modalDescription).not.toBeEmpty();
+  test.describe('when the first experience card is open', () => {
+    test.beforeEach(async ({ page }) => {
+      const home = new HomePage(page);
+      await home.experienceCards.first().click();
+      await expect(home.experienceModal).toBeVisible();
+    });
+
+    test('The modal displays content', async ({ page }) => {
+      const home = new HomePage(page);
+      await expect(home.modalTitle).not.toBeEmpty();
+      await expect(home.modalDescription).not.toBeEmpty();
+    });
+
+    test('The modal closes when X button is clicked', async ({ page }) => {
+      const home = new HomePage(page);
+      await home.modalClose.click();
+      await expect(home.experienceModal).toBeHidden();
+    });
+
+    test('The modal closes when Escape key is pressed', async ({ page }) => {
+      const home = new HomePage(page);
+      await page.keyboard.press('Escape');
+      await expect(home.experienceModal).toBeHidden();
+    });
+
+    test('The previous arrow is not shown', async ({ page }) => {
+      const home = new HomePage(page);
+      await expect(home.modalPrev).not.toBeAttached();
+    });
+
+    test('The next arrow is shown', async ({ page }) => {
+      const home = new HomePage(page);
+      await expect(home.modalNext).toBeVisible();
+    });
+
+    test('Clicking next arrow navigates to the next card', async ({ page }) => {
+      const home = new HomePage(page);
+      const firstTitle = await home.modalTitle.textContent();
+      await home.modalNext.click();
+      await expect(home.modalTitle).not.toHaveText(firstTitle!);
+      await expect(home.modalPrev).toBeVisible();
+    });
+
+    test('ArrowRight key navigates to the next card', async ({ page }) => {
+      const home = new HomePage(page);
+      const firstTitle = await home.modalTitle.textContent();
+      await page.keyboard.press('ArrowRight');
+      await expect(home.modalTitle).not.toHaveText(firstTitle!);
+    });
+
+    test('Company name links to LinkedIn profile and shows the LinkedIn icon', async ({ page }) => {
+      const home = new HomePage(page);
+      await expect(home.modalCompany).toHaveAttribute('href', /linkedin\.com/i);
+      await expect(home.modalCompany.locator('svg')).toBeVisible();
+    });
   });
 
-  test('Experience modal closes when X button is clicked', async ({ page }) => {
-    const home = new HomePage(page);
-    await home.experienceCards.first().click();
-    await expect(home.experienceModal).toBeVisible();
-    await home.modalClose.click();
-    await expect(home.experienceModal).toBeHidden();
-  });
+  test.describe('when the last experience card is open', () => {
+    test.beforeEach(async ({ page }) => {
+      const home = new HomePage(page);
+      await home.experienceCards.last().click();
+      await expect(home.experienceModal).toBeVisible();
+    });
 
-  test('Experience modal closes when Escape key is pressed', async ({ page }) => {
-    const home = new HomePage(page);
-    await home.experienceCards.first().click();
-    await expect(home.experienceModal).toBeVisible();
-    await page.keyboard.press('Escape');
-    await expect(home.experienceModal).toBeHidden();
-  });
+    test('The next arrow is not shown', async ({ page }) => {
+      const home = new HomePage(page);
+      await expect(home.modalNext).not.toBeAttached();
+    });
 
-  test('First card does not show previous arrow', async ({ page }) => {
-    const home = new HomePage(page);
-    await home.experienceCards.first().click();
-    await expect(home.experienceModal).toBeVisible();
-    await expect(home.modalPrev).not.toBeAttached();
-  });
+    test('The previous arrow is shown', async ({ page }) => {
+      const home = new HomePage(page);
+      await expect(home.modalPrev).toBeVisible();
+    });
 
-  test('First card shows next arrow', async ({ page }) => {
-    const home = new HomePage(page);
-    await home.experienceCards.first().click();
-    await expect(home.experienceModal).toBeVisible();
-    await expect(home.modalNext).toBeVisible();
-  });
-
-  test('Clicking next arrow navigates to the next card', async ({ page }) => {
-    const home = new HomePage(page);
-    await home.experienceCards.first().click();
-    await expect(home.experienceModal).toBeVisible();
-    const firstTitle = await home.modalTitle.textContent();
-    await home.modalNext.click();
-    await expect(home.modalTitle).not.toHaveText(firstTitle!);
-    await expect(home.modalPrev).toBeVisible();
-  });
-
-  test('Last card does not show next arrow', async ({ page }) => {
-    const home = new HomePage(page);
-    await home.experienceCards.last().click();
-    await expect(home.experienceModal).toBeVisible();
-    await expect(home.modalNext).not.toBeAttached();
-  });
-
-  test('Last card shows previous arrow', async ({ page }) => {
-    const home = new HomePage(page);
-    await home.experienceCards.last().click();
-    await expect(home.experienceModal).toBeVisible();
-    await expect(home.modalPrev).toBeVisible();
-  });
-
-  test('Clicking previous arrow navigates to the previous card', async ({ page }) => {
-    const home = new HomePage(page);
-    await home.experienceCards.last().click();
-    await expect(home.experienceModal).toBeVisible();
-    const lastTitle = await home.modalTitle.textContent();
-    await home.modalPrev.click();
-    await expect(home.modalTitle).not.toHaveText(lastTitle!);
-    await expect(home.modalNext).toBeVisible();
-  });
-
-  test('ArrowRight key navigates to the next card', async ({ page }) => {
-    const home = new HomePage(page);
-    await home.experienceCards.first().click();
-    await expect(home.experienceModal).toBeVisible();
-    const firstTitle = await home.modalTitle.textContent();
-    await page.keyboard.press('ArrowRight');
-    await expect(home.modalTitle).not.toHaveText(firstTitle!);
+    test('Clicking previous arrow navigates to the previous card', async ({ page }) => {
+      const home = new HomePage(page);
+      const lastTitle = await home.modalTitle.textContent();
+      await home.modalPrev.click();
+      await expect(home.modalTitle).not.toHaveText(lastTitle!);
+      await expect(home.modalNext).toBeVisible();
+    });
   });
 
   test('ArrowLeft key navigates to the previous card', async ({ page }) => {
@@ -170,14 +172,6 @@ test.describe('Experience', () => {
     await page.keyboard.press('ArrowLeft');
     await expect(home.modalTitle).not.toHaveText(secondTitle!);
     await expect(home.modalPrev).not.toBeAttached();
-  });
-
-  test('Company name in modal links to LinkedIn profile and shows the LinkedIn icon', async ({ page }) => {
-    const home = new HomePage(page);
-    await home.experienceCards.first().click();
-    await expect(home.experienceModal).toBeVisible();
-    await expect(home.modalCompany).toHaveAttribute('href', /linkedin\.com/i);
-    await expect(home.modalCompany.locator('svg')).toBeVisible();
   });
 });
 
@@ -192,21 +186,15 @@ test.describe('Dark Mode', () => {
     await expect(home.darkModeToggle).toBeVisible();
   });
 
-  test('User can enable dark mode', async ({ page }) => {
+  test('User can toggle dark mode on and off', async ({ page }) => {
     const home = new HomePage(page);
     await expect(page.locator('html')).not.toHaveClass(/\bdark\b/);
     await expect(home.darkModeToggle.locator('svg[data-icon="moon"]')).toBeVisible();
     await home.darkModeToggle.click();
-    await expect(page.locator('html')).toHaveClass(/\bdark\b/);
-    await expect(home.darkModeToggle).toHaveAttribute('aria-pressed', 'true');
-    await expect(home.darkModeToggle.locator('svg[data-icon="sun"]')).toBeVisible();
-  });
-
-  test('User can disable dark mode', async ({ page }) => {
-    const home = new HomePage(page);
-    await home.darkModeToggle.click();
-    await expect(page.locator('html')).toHaveClass(/\bdark\b/);
-    await expect(home.darkModeToggle.locator('svg[data-icon="sun"]')).toBeVisible();
+    // Soft assertions so the disable step always runs even if enable assertions fail
+    await expect.soft(page.locator('html')).toHaveClass(/\bdark\b/);
+    await expect.soft(home.darkModeToggle).toHaveAttribute('aria-pressed', 'true');
+    await expect.soft(home.darkModeToggle.locator('svg[data-icon="sun"]')).toBeVisible();
     await home.darkModeToggle.click();
     await expect(page.locator('html')).not.toHaveClass(/\bdark\b/);
     await expect(home.darkModeToggle).toHaveAttribute('aria-pressed', 'false');


### PR DESCRIPTION
## Summary

- Merges the separate "enable dark mode" and "disable dark mode" tests into a single toggle test across all three frameworks; Playwright uses `expect.soft()` on the enable assertions so the disable step always runs
- Wraps the 8 "first card" and 3 "last card" experience modal tests in nested describe groups (Playwright/Cypress) or helper functions (TestCafe) with shared `beforeEach` setup, eliminating repeated click + modal visibility boilerplate
- Adds `test:testcafe` npm script to run TestCafe against the live site, with `--skip-js-errors` applied to both the new script and `test:local:testcafe`

## Test plan
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes
- [ ] `npm run format:check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)