### PR TITLE
Add CI run history tooltip tests; add test:all script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ devtool.code-workspace
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+.playwright-cli/

--- a/models/playwright/personal-site/projects-page.ts
+++ b/models/playwright/personal-site/projects-page.ts
@@ -15,6 +15,13 @@ class ProjectsPage {
   readonly stackBlitzLink: Locator;
   readonly backToHomeLink: Locator;
 
+  readonly runHistorySection: Locator;
+  readonly playwrightCiRow: Locator;
+  readonly testcafeCiRow: Locator;
+  readonly cypressCiRow: Locator;
+  readonly runSquares: Locator;
+  readonly runSquareTooltips: Locator;
+
   constructor(page: Page) {
     this.page = page;
     this.heading = page.getByRole('heading', { level: 1 });
@@ -30,6 +37,12 @@ class ProjectsPage {
     this.githubLink = page.getByTestId('github-repo-link');
     this.stackBlitzLink = page.getByTestId('stackblitz-section').getByRole('link');
     this.backToHomeLink = page.getByTestId('back-link');
+    this.runHistorySection = page.getByTestId('run-history');
+    this.playwrightCiRow = page.getByTestId('framework-ci-playwright');
+    this.testcafeCiRow = page.getByTestId('framework-ci-testcafe');
+    this.cypressCiRow = page.getByTestId('framework-ci-cypress');
+    this.runSquares = page.getByTestId('run-square');
+    this.runSquareTooltips = page.getByTestId('run-square-tooltip');
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "eslint-plugin-cypress": "^3.0.0",
         "eslint-plugin-playwright": "^2.10.4",
         "playwright": "^1.45.3",
+        "playwright-cli": "^0.262.0",
         "prettier": "^3.8.3",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.60.0"
@@ -6586,6 +6587,14 @@
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
+    },
+    "node_modules/playwright-cli": {
+      "version": "0.262.0",
+      "resolved": "https://registry.npmjs.org/playwright-cli/-/playwright-cli-0.262.0.tgz",
+      "integrity": "sha512-0ZcfJtffYv0NglJE5RcR3l89j8Hpoo7EoH/3A/1g6+gCIKp9Yq1QqKCqzcifHVBmIXE4A21JN2edkC1xzhf2Hw==",
+      "deprecated": "This package is deprecated, use @playwright/cli instead.",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/playwright-core": {
       "version": "1.60.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "eslint-plugin-cypress": "^3.0.0",
     "eslint-plugin-playwright": "^2.10.4",
     "playwright": "^1.45.3",
+    "playwright-cli": "^0.262.0",
     "prettier": "^3.8.3",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.60.0"
@@ -30,8 +31,9 @@
     "test:cypress": "cypress run --config-file config/cypress.config.cjs",
     "test:local": "BASE_URL=http://localhost:5173 playwright test --config config/playwright.config.js --project=personal-site-chrome --project=personal-site-firefox --project=personal-site-safari",
     "test:local:cypress": "BASE_URL=http://localhost:5173 cypress run --config-file config/cypress.config.cjs",
-    "test:testcafe": "npx testcafe --config-file config/.testcaferc.json chrome tests/TestCafe/personal-site --skip-js-errors",
-    "test:local:testcafe": "BASE_URL=http://localhost:5173 npx testcafe --config-file config/.testcaferc.json chrome tests/TestCafe/personal-site --skip-js-errors"
+    "test:testcafe": "npx testcafe --config-file config/.testcaferc.json chrome:headless tests/TestCafe/personal-site --skip-js-errors",
+    "test:local:testcafe": "BASE_URL=http://localhost:5173 npx testcafe --config-file config/.testcaferc.json chrome tests/TestCafe/personal-site --skip-js-errors",
+    "test:all": "npm run test; npm run test:cypress; npm run test:testcafe"
   },
   "repository": {
     "type": "git",

--- a/tests/playwright/personal-site/projects.spec.ts
+++ b/tests/playwright/personal-site/projects.spec.ts
@@ -63,6 +63,53 @@ test.describe('File Browser', () => {
   });
 });
 
+test.describe('CI Run History', () => {
+  test('User can see the CI run history section', async ({ page }) => {
+    const projects = new ProjectsPage(page);
+    await expect(projects.runHistorySection).toBeVisible();
+  });
+
+  test('User can see run history for each framework', async ({ page }) => {
+    const projects = new ProjectsPage(page);
+    await expect(projects.playwrightCiRow).toBeVisible();
+    await expect(projects.testcafeCiRow).toBeVisible();
+    await expect(projects.cypressCiRow).toBeVisible();
+  });
+
+  test('User can see run squares for each framework', async ({ page }) => {
+    const projects = new ProjectsPage(page);
+    const playwrightSquares = projects.playwrightCiRow.getByTestId('run-square');
+    const testcafeSquares = projects.testcafeCiRow.getByTestId('run-square');
+    const cypressSquares = projects.cypressCiRow.getByTestId('run-square');
+    await expect(playwrightSquares.first()).toBeVisible();
+    await expect(testcafeSquares.first()).toBeVisible();
+    await expect(cypressSquares.first()).toBeVisible();
+  });
+
+  test('User can see a tooltip when hovering a run square', async ({ page }) => {
+    const projects = new ProjectsPage(page);
+    const firstSquare = projects.playwrightCiRow.getByTestId('run-square').first();
+    const firstTooltip = projects.playwrightCiRow.getByTestId('run-square-tooltip').first();
+    await firstSquare.hover();
+    await expect(firstTooltip).toBeVisible();
+  });
+
+  test('Tooltip shows run status and number', async ({ page }) => {
+    const projects = new ProjectsPage(page);
+    const firstSquare = projects.playwrightCiRow.getByTestId('run-square').first();
+    const firstTooltip = projects.playwrightCiRow.getByTestId('run-square-tooltip').first();
+    await firstSquare.hover();
+    await expect(firstTooltip).toBeVisible();
+    await expect(firstTooltip).toHaveText(/^(Passed|Failed) – Run #\d+/);
+  });
+
+  test('Run squares link to GitHub Actions', async ({ page }) => {
+    const projects = new ProjectsPage(page);
+    const firstSquare = projects.playwrightCiRow.getByTestId('run-square').first();
+    await expect(firstSquare).toHaveAttribute('href', /github\.com\/sarahncrowe\/sample-automation\/actions\/runs\//);
+  });
+});
+
 test.describe('Links', () => {
   test('User can navigate to the GitHub repository', async ({ page }) => {
     const projects = new ProjectsPage(page);


### PR DESCRIPTION
## Summary

- Adds 6 Playwright tests for the CI run history section on `/projects`, covering section/row visibility, run square presence, tooltip-on-hover behavior, tooltip content format, and GitHub Actions link hrefs
- Extends `ProjectsPage` POM with locators for the run history section, per-framework rows (`framework-ci-playwright/testcafe/cypress`), run squares, and tooltips
- Adds `npm run test:all` to run Playwright → Cypress → TestCafe sequentially (continues on failure so all results are visible)
- Fixes `test:testcafe` to use `chrome:headless` (the CLI positional arg `chrome` was silently overriding the `chrome:headless` setting in `.testcaferc.json`)
- Adds `.playwright-cli/` to `.gitignore`

## Test plan

- [ ] `npm run test:all` completes all three suites
- [ ] New CI Run History tests pass: `npm run test -- --grep "CI Run History"`
- [ ] TypeScript check passes: `npm run typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)