### PR TITLE
Run E2E tests on push to main

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,5 +1,7 @@
 name: Cypress Tests
 on:
+  push:
+    branches: [main]
   schedule:
     - cron: '0 10 * * 3'
     - cron: '0 10 * * 6'

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -3,6 +3,8 @@
 
 name: Playwright Tests
 on:
+  push:
+    branches: [main]
   schedule: # Wed/Sat at 10 UTC
     - cron: '0 10 * * 3'
     - cron: '0 10 * * 6'

--- a/.github/workflows/testcafe.yml
+++ b/.github/workflows/testcafe.yml
@@ -1,5 +1,7 @@
 name: TestCafe Tests
 on:
+  push:
+    branches: [main]
   schedule:
     - cron: '0 10 * * 3'
     - cron: '0 10 * * 6'


### PR DESCRIPTION
## Summary
- Adds `push: branches: [main]` trigger to Playwright, Cypress, and TestCafe workflows
- E2E tests now run automatically after every merge to main, catching regressions immediately rather than waiting for the next scheduled run

## Test plan
- [ ] Merge a PR to main and confirm all three E2E workflows appear in the Actions tab for the merge commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)